### PR TITLE
Copy OrpheusDL directories to desired container paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,10 @@ WORKDIR /app
 # Copy source files (adjust as needed)
 COPY . /app
 
+# Copy OrpheusDL core and modules into expected container locations
+COPY external/orpheusdl /orpheusdl
+RUN mkdir -p /orpheusdl/modules
+COPY external/orpheusdl-qobuz /orpheusdl/modules/qobuz
+
 # Default command
 CMD ["sh"]


### PR DESCRIPTION
## Summary
- copy the external OrpheusDL core folder into /orpheusdl inside the container image
- copy the external OrpheusDL Qobuz module into /orpheusdl/modules/qobuz so it is available at runtime

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd1dd2f348832f8d915632f7cb63cb