### PR TITLE
Initialize submodules during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,22 @@
 FROM alpine:3.20
 
 # Install dependencies (example: curl + bash)
-RUN apk add --no-cache curl bash
+RUN apk add --no-cache curl bash git
 
 # Set working dir
 WORKDIR /app
 
 # Copy source files (adjust as needed)
 COPY . /app
+
+# Fetch git submodules so their contents are available during the build
+RUN git config --global --add safe.directory /app \
+    && git -C /app submodule update --init --recursive
+
+# Copy OrpheusDL core and modules into expected container locations
+RUN mkdir -p /orpheusdl/modules/qobuz \
+    && cp -a /app/external/orpheusdl/. /orpheusdl/ \
+    && cp -a /app/external/orpheusdl-qobuz/. /orpheusdl/modules/qobuz/
 
 # Default command
 CMD ["sh"]


### PR DESCRIPTION
## Summary
- install git in the container image so submodules can be fetched during the build
- run `git submodule update --init --recursive` after copying the repository into the image
- copy the populated OrpheusDL core and Qobuz module directories into `/orpheusdl` and `/orpheusdl/modules/qobuz`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd1dd2f348832f8d915632f7cb63cb