### PR TITLE
Allow pip installs to break system packages during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN git config --global --add safe.directory /app \
     && git -C /app submodule update --init --recursive
 
 # Install OrpheusDL Python dependencies inside the image
-RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir -r /app/external/orpheusdl/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip --break-system-packages \
+    && pip3 install --no-cache-dir --break-system-packages -r /app/external/orpheusdl/requirements.txt
 
 # Copy OrpheusDL core and modules into expected container locations
 RUN mkdir -p /orpheusdl/modules/qobuz \


### PR DESCRIPTION
## Summary
- add the --break-system-packages flag to pip invocations in the Dockerfile so container builds succeed in externally managed environments

## Testing
- docker build -t test . *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd24ac92b0832f926be40191bf7b43