### PR TITLE
Use bash entrypoint and set OrpheusDL workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,9 @@ RUN mkdir -p /orpheusdl/modules/qobuz \
     && cp -a /app/external/orpheusdl/. /orpheusdl/ \
     && cp -a /app/external/orpheusdl-qobuz/. /orpheusdl/modules/qobuz/
 
-# Default command
-CMD ["sh"]
+# Change to the OrpheusDL directory at runtime so bundled modules are detected
+WORKDIR /orpheusdl
+
+# Run commands through bash so built-ins like `cd` are available when overriding CMD
+ENTRYPOINT ["/bin/bash", "-lc"]
+CMD ["bash"]


### PR DESCRIPTION
## Summary
- set the runtime working directory to /orpheusdl so the bundled modules are visible
- run runtime commands through a bash entrypoint so built-ins like `cd` are available when overriding the default command

## Testing
- not run (container configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd272370ac832fbbfc03daf8caa6a9