### PR TITLE
Add entrypoint to configure Qobuz credentials via env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ WORKDIR /app
 # Copy source files (adjust as needed)
 COPY . /app
 
+# Provide an entrypoint that injects runtime credentials into the settings file
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Fetch git submodules so their contents are available during the build
 RUN git config --global --add safe.directory /app \
     && git -C /app submodule update --init --recursive
@@ -37,6 +41,5 @@ RUN mkdir -p /orpheusdl/modules/qobuz \
 # Change to the OrpheusDL directory at runtime so bundled modules are detected
 WORKDIR /orpheusdl
 
-# Run commands through bash so built-ins like `cd` are available when overriding CMD
-ENTRYPOINT ["/bin/bash", "-lc"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # OrpheusDL-Container
+
+## Runtime configuration
+
+The container entrypoint updates `/app/settings.json` and `/orpheusdl/settings.json` with
+credential values from environment variables when the container starts. Set any of the
+following variables when running the container to inject the values into the Qobuz module
+settings:
+
+- `QOBUZ_APP_ID` or `APP_ID`
+- `QOBUZ_APP_SECRET` or `APP_SECRET`
+- `QOBUZ_USERNAME`
+- `QOBUZ_PASSWORD`
+
+Lowercase variants of these names are also respected. Values are only written when the
+corresponding variable is provided, so existing settings remain unchanged unless explicitly
+overridden at runtime.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+CONFIG_PATHS = [
+    Path("/app/settings.json"),
+    Path("/orpheusdl/settings.json"),
+]
+ENV_MAPPING = {
+    "app_id": ("QOBUZ_APP_ID", "APP_ID", "app_id"),
+    "app_secret": ("QOBUZ_APP_SECRET", "APP_SECRET", "app_secret"),
+    "username": ("QOBUZ_USERNAME", "USERNAME", "username"),
+    "password": ("QOBUZ_PASSWORD", "PASSWORD", "password"),
+}
+
+for settings_path in CONFIG_PATHS:
+    if not settings_path.exists():
+        continue
+    try:
+        settings = json.loads(settings_path.read_text())
+    except json.JSONDecodeError:
+        continue
+
+    modules = settings.setdefault("modules", {})
+    qobuz = modules.setdefault("qobuz", {})
+    updated = False
+
+    for key, env_names in ENV_MAPPING.items():
+        for env_name in env_names:
+            if env_name not in os.environ:
+                continue
+            value = os.environ[env_name]
+            if qobuz.get(key) != value:
+                qobuz[key] = value
+                updated = True
+            break
+
+    if updated:
+        settings_path.write_text(json.dumps(settings, indent=4) + "\n")
+PY
+
+if [ $# -eq 0 ]; then
+    set -- bash
+fi
+
+exec /bin/bash -lc "$*"


### PR DESCRIPTION
## Summary
- add a Docker entrypoint script that populates Qobuz credentials in settings.json from environment variables at container startup
- wire the Dockerfile to install and use the new entrypoint and document the runtime variables in the README

## Testing
- bash -n docker-entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68cd39e56c08832fb61f21c399d66e7f