### PR TITLE
Fix entrypoint command execution

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,7 +44,7 @@ for settings_path in CONFIG_PATHS:
 PY
 
 if [ $# -eq 0 ]; then
-    set -- bash
+    set -- /bin/bash -l
 fi
 
-exec /bin/bash -lc "$*"
+exec "$@"


### PR DESCRIPTION
## Summary
- run the default shell as a login shell when no command is provided
- execute user-supplied commands directly instead of reparsing them through an extra bash layer so Python arguments are preserved

## Testing
- ./docker-entrypoint.sh python3 --version
- ./docker-entrypoint.sh python3 -c "print('hello')"


------
https://chatgpt.com/codex/tasks/task_e_68cd3e728838832f9e9101284d084fbe