### PR TITLE
Adjust default runtime behaviour

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,3 @@ RUN mkdir -p /orpheusdl/modules/qobuz \
 WORKDIR /orpheusdl
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # OrpheusDL-Container
 
+## Default runtime behaviour
+
+Running the published image with no explicit command starts the background list UI and
+the nightly list scheduler automatically:
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/theminecraftguyguru/orpheusdl-container
+```
+
+The UI listens on the port defined by `$LISTS_WEB_PORT` (default `8080`). The entrypoint
+keeps the scheduler in the foreground so `docker logs` shows progress from the nightly
+loop. To open an interactive shell instead of the scheduler, override the entrypoint:
+
+```bash
+docker run --rm -it --entrypoint bash ghcr.io/theminecraftguyguru/orpheusdl-container
+```
+
+Any other command supplied to `docker run … <command>` executes through the entrypoint
+with stdout forced to unbuffered mode so progress appears in the container logs.
+
 ## Runtime configuration
 
 The container entrypoint updates `/app/settings.json` and `/orpheusdl/settings.json` with

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -98,6 +98,14 @@ export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"
 
 cmd=("$@")
 
+if [ "${#cmd[@]}" -eq 1 ]; then
+    case "${cmd[0]}" in
+        bash|sh|/bin/sh)
+            cmd=()
+            ;;
+    esac
+fi
+
 if [ "${#cmd[@]}" -eq 0 ]; then
     python3 -u /app/list_ui_server.py &
     web_pid=$!


### PR DESCRIPTION
## Summary
- treat bare shell invocations as empty commands so the scheduler and UI start automatically
- remove the bash CMD so the default docker run falls back to the entrypoint automation
- document the default container startup flow and how to request an interactive shell

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfa58fb3f4832f9c201f0450c1cb50