### PR TITLE
Integrate OrpheusDL Qobuz API into artist search UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ settings:
 
 - `QOBUZ_APP_ID` or `APP_ID`
 - `QOBUZ_APP_SECRET` or `APP_SECRET`
-- `QOBUZ_USERNAME`
-- `QOBUZ_PASSWORD`
+- `QOBUZ_USER_ID` or `USER_ID`
+- `QOBUZ_TOKEN`, `QOBUZ_USER_AUTH_TOKEN`, `QOBUZ_AUTH_TOKEN`, `TOKEN`, or `USER_AUTH_TOKEN`
 
-Lowercase variants of these names are also respected. Values are only written when the
-corresponding variable is provided, so existing settings remain unchanged unless explicitly
-overridden at runtime.
+Lowercase variants of these names are also respected. The entrypoint mirrors the user ID
+and token values into the legacy username/password fields for compatibility. Values are
+only written when the corresponding variable is provided, so existing settings remain
+unchanged unless explicitly overridden at runtime.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -68,8 +68,16 @@ target_path = Path('/orpheusdl/config/settings.json')
 ENV_MAPPING = {
     'app_id': ('QOBUZ_APP_ID', 'APP_ID', 'app_id'),
     'app_secret': ('QOBUZ_APP_SECRET', 'APP_SECRET', 'app_secret'),
-    'username': ('QOBUZ_USERNAME', 'USERNAME', 'username'),
-    'password': ('QOBUZ_PASSWORD', 'PASSWORD', 'password'),
+    'user_id': ('QOBUZ_USER_ID', 'USER_ID', 'user_id'),
+    'token': (
+        'QOBUZ_TOKEN',
+        'QOBUZ_USER_AUTH_TOKEN',
+        'QOBUZ_AUTH_TOKEN',
+        'TOKEN',
+        'USER_AUTH_TOKEN',
+        'user_auth_token',
+        'token',
+    ),
 }
 
 if settings_path.exists():
@@ -89,6 +97,14 @@ if settings_path.exists():
                     if qobuz.get(key) != value:
                         qobuz[key] = value
                     break
+
+        user_id = qobuz.get('user_id')
+        if user_id is not None and qobuz.get('username') != user_id:
+            qobuz['username'] = user_id
+
+        token = qobuz.get('token')
+        if token is not None and qobuz.get('password') != token:
+            qobuz['password'] = token
 
         target_path.write_text(json.dumps(settings, indent=4) + '\n')
 PY

--- a/settings.json
+++ b/settings.json
@@ -73,7 +73,9 @@
             "app_secret": "",
             "quality_format": "{sample_rate}kHz {bit_depth}bit",
             "username": "",
-            "password": ""
+            "password": "",
+            "user_id": "",
+            "token": ""
         }
     }
 }


### PR DESCRIPTION
## Summary
- load the bundled OrpheusDL Qobuz client inside the list UI and run artist searches through it using cached credentials
- surface Qobuz user_id and token alongside app id/secret from environment variables when generating settings.json defaults
- map the Qobuz user ID and token into the legacy username/password settings fields and document the updated environment variables

## Testing
- python -m compileall list_ui_server.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb4089fbc832fa7c4a85b0dfd4ce1