### PR TITLE
Fix escape map quoting in artist search script

### DIFF
--- a/list_ui_server.py
+++ b/list_ui_server.py
@@ -46,7 +46,7 @@ ARTIST_SEARCH_SCRIPT = """
   }
 
   let activeController = null;
-  const escapeMap = {"&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;"};
+  const escapeMap = {"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': '&quot;', "'": "&#39;"};
 
   function escapeHtml(value) {
     return String(value).replace(/[&<>"']/g, (char) => escapeMap[char] || char);


### PR DESCRIPTION
## Summary
- update the artist search escapeMap double-quote entry to use a valid JavaScript string literal

## Testing
- python list_ui_server.py (manual stop)
- curl -s http://127.0.0.1:8080 | rg "escapeMap"


------
https://chatgpt.com/codex/tasks/task_e_68d02afed678832fb20c2ecff215b6eb