### PR TITLE
Fix Qobuz client lock deadlock

### DIFF
--- a/list_ui_server.py
+++ b/list_ui_server.py
@@ -182,7 +182,7 @@ if _ORPHEUSDL_PATH.exists():
     if path_str not in sys.path:
         sys.path.insert(0, path_str)
 
-_QOBUZ_MODULE_LOCK = threading.Lock()
+_QOBUZ_MODULE_LOCK = threading.RLock()
 _QOBUZ_API_MODULE = None
 _QOBUZ_CLIENT = None
 _QOBUZ_CLIENT_CREDS: Optional[Dict[str, str]] = None

--- a/tests/test_list_ui_server.py
+++ b/tests/test_list_ui_server.py
@@ -16,6 +16,7 @@ class _TimeoutClient:
 class _DummyHandler(list_ui_server.ListRequestHandler):
     def __init__(self):
         self.responses = []
+        self.client_address = ("127.0.0.1", 0)
 
     def send_json(self, payload, status: HTTPStatus = HTTPStatus.OK) -> None:  # type: ignore[override]
         self.responses.append((payload, status))


### PR DESCRIPTION
## Summary
- switch the Qobuz module lock to an RLock so nested lookups no longer deadlock
- update the artist search timeout test helper with a client address to match BaseHTTPRequestHandler expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d052d7021c832f9fc4508e617d2a1f