### PR TITLE
Delete artist folders when removing artists from UI

### DIFF
--- a/tests/test_list_ui_server.py
+++ b/tests/test_list_ui_server.py
@@ -1,5 +1,7 @@
+import tempfile
 import unittest
 from http import HTTPStatus
+from pathlib import Path
 from unittest import mock
 from urllib.parse import urlparse
 
@@ -34,6 +36,59 @@ class ArtistSearchTimeoutTests(unittest.TestCase):
         payload, status = handler.responses[0]
         self.assertEqual(status, HTTPStatus.BAD_GATEWAY)
         self.assertEqual(payload.get("error"), "Qobuz search timed out.")
+
+
+class RemoveArtistDirectoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+        base_path = Path(self._tempdir.name)
+        self.music_dir = base_path / "music"
+        self.lists_dir = base_path / "lists"
+        self.music_dir.mkdir()
+        self.lists_dir.mkdir()
+
+        self._original_music_dir = list_ui_server.MUSIC_DIR
+        self._original_lists_dir = list_ui_server.LISTS_DIR
+        list_ui_server.MUSIC_DIR = self.music_dir
+        list_ui_server.LISTS_DIR = self.lists_dir
+
+        self.addCleanup(self._restore_paths)
+
+    def _restore_paths(self) -> None:
+        list_ui_server.MUSIC_DIR = self._original_music_dir
+        list_ui_server.LISTS_DIR = self._original_lists_dir
+
+    def _write_artists(self, entries):
+        with list_ui_server._lock:
+            list_ui_server._write_artist_entries_locked(entries)
+
+    def test_remove_artist_deletes_music_directory(self):
+        artist_name = "Owl City"
+        artist_id = "12345"
+        artist_path = self.music_dir / artist_name
+        artist_path.mkdir()
+        (artist_path / "track.mp3").write_text("data", encoding="utf-8")
+
+        self._write_artists([{"id": artist_id, "name": artist_name}])
+
+        success, message = list_ui_server.remove_entry("artist", 0)
+
+        self.assertTrue(success)
+        self.assertIn(artist_name, message)
+        self.assertFalse(artist_path.exists())
+
+    def test_remove_artist_without_directory_succeeds(self):
+        artist_name = "Imagine Dragons"
+        artist_id = "67890"
+
+        self._write_artists([{"id": artist_id, "name": artist_name}])
+
+        success, message = list_ui_server.remove_entry("artist", 0)
+
+        self.assertTrue(success)
+        self.assertIn(artist_name, message)
+        self.assertFalse((self.music_dir / artist_name).exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove artist music directories under MUSIC_DIR when an artist entry is deleted and guard against unsafe paths
- add regression tests covering directory cleanup on artist removal

## Testing
- python3 -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68d0800f0740832fb36013f76374584f