### PR TITLE
docs: promote docker compose workflow and add env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy this file to ".env" and populate the values before running docker compose.
+# Never commit the resulting .env file to source control.
+
+# Required Qobuz credentials
+QOBUZ_APP_ID=your_app_id
+QOBUZ_APP_SECRET=your_app_secret
+QOBUZ_USER_ID=your_user_id
+QOBUZ_TOKEN=your_user_token
+
+# Apple Music module (required for lyrics/covers/credits if you use those features)
+APPLE_MUSIC_USER_TOKEN=your_apple_music_user_token
+
+# Optional notifications
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
+# Optional runtime tuning
+LISTS_WEB_PORT=8080
+LISTS_WEB_HOST=0.0.0.0
+LISTS_WEB_LOG_LEVEL=INFO
+LISTS_SCHEDULER_INTERVAL=5
+LISTS_SCHEDULER_IDLE_SLEEP=60


### PR DESCRIPTION
## Summary
- replace docker run examples in the README with docker compose workflows and safer guidance
- highlight use of a .env file and link to the new example template for managing secrets
- refresh manual command guidance and compose sample to emphasise modern best practices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60c5239c8832f99b34c2ba30898d2