### PR TITLE
Update default module defaults to generic providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ Every leaf value in [`settings.json`](./settings.json) can be overridden via an 
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `ORPHEUSDL_GLOBAL_MODULE_DEFAULTS_LYRICS` | `applemusic` | Default lyrics provider. |
-| `ORPHEUSDL_GLOBAL_MODULE_DEFAULTS_COVERS` | `applemusic` | Default cover art provider. |
-| `ORPHEUSDL_GLOBAL_MODULE_DEFAULTS_CREDITS` | `applemusic` | Default credits provider. |
+| `ORPHEUSDL_GLOBAL_MODULE_DEFAULTS_LYRICS` | `default` | Default lyrics provider. |
+| `ORPHEUSDL_GLOBAL_MODULE_DEFAULTS_COVERS` | `default` | Default cover art provider. |
+| `ORPHEUSDL_GLOBAL_MODULE_DEFAULTS_CREDITS` | `default` | Default credits provider. |
+
+Set any of these variables to `applemusic` if you intend to supply Apple Music credentials and want the bundled module to handle lyrics, artwork, or credits lookups.
 
 #### `global.lyrics`
 

--- a/settings.json
+++ b/settings.json
@@ -22,9 +22,9 @@
             "spatial_codecs": true
         },
         "module_defaults": {
-            "lyrics": "applemusic",
-            "covers": "applemusic",
-            "credits": "applemusic"
+            "lyrics": "default",
+            "covers": "default",
+            "credits": "default"
         },
         "lyrics": {
             "embed_lyrics": true,


### PR DESCRIPTION
## Summary
- switch the default module provider configuration in `settings.json` from `applemusic` to `default`
- update the README to reflect the new defaults and explain how to opt into the Apple Music provider

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60d1227e4832f864375141652b473