### PR TITLE
Use self-hosted runner for Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- update the Docker publish workflow to execute on a self-hosted runner instead of GitHub-hosted Ubuntu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60e9a02ec832fb8261dd62c7d8163