### PR TITLE
Add CI workflow for linting, testing, and Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install lint dependencies
+        run: python -m pip install --upgrade pip ruff
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Verify Python bytecode compiles
+        run: python -m compileall list_ui_server.py notifications.py tests
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest requests
+
+      - name: Run pytest
+        run: pytest
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: orpheusdl:test


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow that runs on pushes to main and pull requests
- lint and compile the Python sources with ruff and `python -m compileall`
- execute the pytest suite and build the container image to keep the Dockerfile healthy

## Testing
- `ruff check .`
- `python -m compileall list_ui_server.py notifications.py tests`
- `pytest`
- `docker build -t orpheusdl:test .` *(fails locally because Docker is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d60f0ec8ec832f8f1f14a7408669af