### PR TITLE
Rebuild queue web UI with React

### DIFF
--- a/webui/main.js
+++ b/webui/main.js
@@ -1,0 +1,803 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'https://esm.sh/react@18';
+import { createRoot } from 'https://esm.sh/react-dom@18/client';
+
+const LIST_ORDER = ['artist', 'album', 'track'];
+const initialState = window.__LIST_UI_STATE__ || {};
+
+const ensureLists = (lists = {}) => ({
+  artist: Array.isArray(lists.artist) ? lists.artist : [],
+  album: Array.isArray(lists.album) ? lists.album : [],
+  track: Array.isArray(lists.track) ? lists.track : [],
+});
+
+const withBannerIds = (banners = []) =>
+  banners
+    .filter((banner) => banner && banner.message)
+    .map((banner, index) => ({
+      id:
+        typeof crypto !== 'undefined' && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `${Date.now()}-${index}-${Math.random().toString(16).slice(2)}`,
+      message: banner.message,
+      isError: Boolean(banner.isError),
+    }));
+
+const normalizeIdentifier = (value) => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  const normalized = String(value).trim();
+  if (!normalized) {
+    return '';
+  }
+  if (
+    normalized.startsWith('.') ||
+    normalized.includes('/') ||
+    normalized.includes('\\') ||
+    normalized.includes('..')
+  ) {
+    return '';
+  }
+  return normalized;
+};
+
+const buildArtistPhotoUrl = (artistId) => {
+  const normalized = normalizeIdentifier(artistId);
+  return normalized ? `/photos/${encodeURIComponent(normalized)}` : '';
+};
+
+const buildAlbumPhotoUrl = (albumId) => {
+  const normalized = normalizeIdentifier(albumId);
+  if (!normalized) {
+    return '';
+  }
+  const albumKey = normalizeIdentifier(`album_${normalized}`);
+  return albumKey ? `/photos/${encodeURIComponent(albumKey)}` : '';
+};
+
+const SEARCH_CONFIG = {
+  artist: {
+    heading: 'Add artists from Qobuz',
+    tagline: 'Queue full artist discographies by searching Qobuz.',
+    idleMessage: 'Use the search to add artists by Qobuz ID.',
+    endpoint: '/api/artist-search',
+    selectEndpoint: '/api/artist-select',
+    fields: [
+      {
+        key: 'artist',
+        label: 'Artist',
+        placeholder: 'Search Qobuz artists',
+        type: 'search',
+        required: true,
+      },
+    ],
+    buildQuery: (inputs) => inputs.artist?.trim() ?? '',
+    buildPayload: (item) => {
+      const id = normalizeIdentifier(item?.id);
+      if (!id) {
+        return null;
+      }
+      return {
+        id,
+        name: (item?.name ?? '').toString(),
+      };
+    },
+    renderPrimary: (item) => item?.name || item?.id || 'Unknown artist',
+    renderSecondary: (item) =>
+      item?.id ? `ID: ${item.id}` : 'Qobuz identifier unavailable',
+    clearOnSuccess: false,
+  },
+  album: {
+    heading: 'Add albums from Qobuz',
+    tagline: 'Search for a release and add it to the queue instantly.',
+    idleMessage: 'Provide album and artist names for best results.',
+    endpoint: '/api/album-search',
+    selectEndpoint: '/api/album-select',
+    fields: [
+      {
+        key: 'title',
+        label: 'Album',
+        placeholder: 'Album name',
+        type: 'search',
+        required: false,
+      },
+      {
+        key: 'artist',
+        label: 'Artist',
+        placeholder: 'Artist name',
+        type: 'search',
+        required: false,
+      },
+    ],
+    buildQuery: (inputs) =>
+      [inputs.title, inputs.artist].map((value) => value?.trim() ?? '').filter(Boolean).join(' '),
+    buildPayload: (item) => {
+      const id = normalizeIdentifier(item?.id ?? item?.value);
+      if (!id) {
+        return null;
+      }
+      return {
+        id,
+        title: (item?.title ?? '').toString(),
+        artist: (item?.artist ?? '').toString(),
+        value: (item?.value ?? '').toString(),
+        lookup: (item?.lookup ?? '').toString(),
+        image: (item?.image ?? '').toString(),
+        photo: (item?.photo ?? '').toString(),
+      };
+    },
+    renderPrimary: (item) => item?.title || item?.value || item?.id || 'Unknown album',
+    renderSecondary: (item) => {
+      const artist = item?.artist ? `Artist: ${item.artist}` : null;
+      const year = item?.year ? `Year: ${item.year}` : null;
+      return [artist, year].filter(Boolean).join(' · ') || 'Qobuz release';
+    },
+    clearOnSuccess: true,
+  },
+  track: {
+    heading: 'Add individual tracks',
+    tagline: 'Queue a specific song using its Qobuz metadata.',
+    idleMessage: 'Combine track, album, and artist names for precise matches.',
+    endpoint: '/api/track-search',
+    selectEndpoint: '/api/track-select',
+    fields: [
+      {
+        key: 'title',
+        label: 'Track',
+        placeholder: 'Track name',
+        type: 'search',
+        required: false,
+      },
+      {
+        key: 'album',
+        label: 'Album',
+        placeholder: 'Album name',
+        type: 'search',
+        required: false,
+      },
+      {
+        key: 'artist',
+        label: 'Artist',
+        placeholder: 'Artist name',
+        type: 'search',
+        required: false,
+      },
+    ],
+    buildQuery: (inputs) =>
+      [inputs.title, inputs.album, inputs.artist]
+        .map((value) => value?.trim() ?? '')
+        .filter(Boolean)
+        .join(' '),
+    buildPayload: (item) => {
+      const id = normalizeIdentifier(item?.id ?? item?.value);
+      if (!id) {
+        return null;
+      }
+      return {
+        id,
+        title: (item?.title ?? '').toString(),
+        album: (item?.album ?? '').toString(),
+        artist: (item?.artist ?? '').toString(),
+        value: (item?.value ?? '').toString(),
+        lookup: (item?.lookup ?? '').toString(),
+        album_id: (item?.album_id ?? item?.albumId ?? '').toString(),
+        image: (item?.image ?? '').toString(),
+        photo: (item?.photo ?? '').toString(),
+      };
+    },
+    renderPrimary: (item) => item?.title || item?.value || item?.id || 'Unknown track',
+    renderSecondary: (item) => {
+      const parts = [];
+      if (item?.artist) {
+        parts.push(item.artist);
+      }
+      if (item?.album) {
+        parts.push(item.album);
+      }
+      return parts.join(' · ') || 'Qobuz track';
+    },
+    clearOnSuccess: true,
+  },
+};
+
+const defaultSearchInputs = Object.fromEntries(
+  Object.entries(SEARCH_CONFIG).map(([key, config]) => [
+    key,
+    Object.fromEntries(config.fields.map((field) => [field.key, ''])),
+  ]),
+);
+
+const makeInitialSearchState = () =>
+  Object.fromEntries(
+    Object.entries(SEARCH_CONFIG).map(([key, config]) => [
+      key,
+      {
+        inputs: { ...defaultSearchInputs[key] },
+        results: [],
+        status: 'idle',
+        message: config.idleMessage,
+      },
+    ]),
+  );
+
+const BannerStack = ({ banners, onDismiss }) => {
+  if (!banners.length) {
+    return null;
+  }
+  return (
+    <div className="banner-stack">
+      {banners.map((banner) => (
+        <div
+          key={banner.id}
+          className={`banner${banner.isError ? ' is-error' : ''}`}
+          role={banner.isError ? 'alert' : 'status'}
+        >
+          <span>{banner.message}</span>
+          <button type="button" onClick={() => onDismiss(banner.id)} aria-label="Dismiss message">
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const NeonButton = React.forwardRef(function NeonButton(
+  { className = '', variant, children, ...props },
+  ref,
+) {
+  const variantClass = variant === 'danger' ? ' is-danger' : variant === 'ghost' ? ' is-ghost' : '';
+  return (
+    <button ref={ref} className={`reactbits-button${variantClass} ${className}`.trim()} {...props}>
+      {children}
+    </button>
+  );
+});
+
+const GlassCard = ({ className = '', padded = true, children }) => (
+  <section className={`reactbits-card ${padded ? 'reactbits-card--padded' : 'reactbits-card--flush'} ${className}`.trim()}>
+    {children}
+  </section>
+);
+
+const Tabs = ({ value, onChange, options }) => (
+  <div className="reactbits-tabs" role="tablist" aria-label="List selector">
+    {options.map((option) => (
+      <button
+        key={option.value}
+        type="button"
+        role="tab"
+        aria-selected={value === option.value}
+        className={`reactbits-tab${value === option.value ? ' is-active' : ''}`}
+        onClick={() => onChange(option.value)}
+      >
+        {option.label}
+      </button>
+    ))}
+  </div>
+);
+
+const EntryList = ({ kind, label, entries, onRemove, disabled, isRefreshing }) => {
+  const countLabel = `${entries.length} entr${entries.length === 1 ? 'y' : 'ies'}`;
+
+  if (!entries.length) {
+    return (
+      <GlassCard>
+        <div className="list-header">
+          <h2>{label}</h2>
+          <span className="count-pill">{countLabel}</span>
+        </div>
+        {isRefreshing ? (
+          <div className="loader" aria-label="Loading entries" />
+        ) : (
+          <div className="empty-state">No entries yet.</div>
+        )}
+      </GlassCard>
+    );
+  }
+
+  return (
+    <GlassCard>
+      <div className="list-header">
+        <h2>{label}</h2>
+        <span className="count-pill">{countLabel}</span>
+      </div>
+      <div className="entry-collection">
+        {entries.map((entry, index) => (
+          <EntryCard
+            key={`${kind}-${entry.id || index}`}
+            kind={kind}
+            entry={entry}
+            index={index}
+            onRemove={onRemove}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </GlassCard>
+  );
+};
+
+const formatLastChecked = (value) => {
+  const normalized = (value ?? '').toString().trim();
+  return normalized || 'Never';
+};
+
+const EntryCard = ({ kind, entry, index, onRemove, disabled }) => {
+  const id = (entry?.id ?? '').toString();
+  const name = (entry?.name ?? '').toString();
+  const title = (entry?.title ?? '').toString();
+  const artist = (entry?.artist ?? '').toString();
+  const album = (entry?.album ?? '').toString();
+  const lastChecked = formatLastChecked(entry?.last_checked_at);
+
+  let primary = id;
+  let subtitle = '';
+  let meta = `Last checked: ${lastChecked}`;
+
+  if (kind === 'artist') {
+    primary = name || id || 'Artist';
+    subtitle = id ? `ID: ${id}` : '';
+  } else if (kind === 'album') {
+    primary = title || id || 'Album';
+    subtitle = [artist && `Artist: ${artist}`, id && `ID: ${id}`].filter(Boolean).join(' · ');
+  } else if (kind === 'track') {
+    primary = title || id || 'Track';
+    subtitle = [artist, album].filter(Boolean).join(' · ');
+    meta = [id && `ID: ${id}`, meta].filter(Boolean).join(' · ');
+  }
+
+  const albumId = entry?.album_id || entry?.albumId;
+  const imageUrl =
+    kind === 'artist'
+      ? buildArtistPhotoUrl(id)
+      : kind === 'album'
+      ? buildAlbumPhotoUrl(id)
+      : kind === 'track'
+      ? buildAlbumPhotoUrl(albumId)
+      : '';
+
+  return (
+    <div className={`entry-card${imageUrl ? '' : ' no-media'}`}>
+      {imageUrl ? (
+        <div className="entry-thumb">
+          <img src={imageUrl} alt="Artwork" loading="lazy" onError={(event) => (event.currentTarget.style.display = 'none')} />
+        </div>
+      ) : null}
+      <div className="entry-content">
+        <div className="entry-title">{primary}</div>
+        {subtitle ? <div className="entry-subtitle">{subtitle}</div> : null}
+        <div className="entry-meta">{meta}</div>
+      </div>
+      <NeonButton
+        type="button"
+        variant="danger"
+        onClick={() => onRemove(kind, index)}
+        disabled={disabled}
+      >
+        Remove
+      </NeonButton>
+    </div>
+  );
+};
+
+const SearchPanel = ({
+  type,
+  config,
+  state,
+  onInputChange,
+  onSubmit,
+  onSelect,
+  disabled,
+}) => {
+  const handleChange = (key, value) => {
+    onInputChange(type, key, value);
+  };
+
+  const submit = (event) => {
+    event.preventDefault();
+    onSubmit(type);
+  };
+
+  return (
+    <GlassCard>
+      <div className="list-header">
+        <div>
+          <h2>{config.heading}</h2>
+          <div className="entry-meta">{config.tagline}</div>
+        </div>
+      </div>
+      <form className="search-form" onSubmit={submit}>
+        <div className="field-grid">
+          {config.fields.map((field) => (
+            <div className="field-group" key={field.key}>
+              <label htmlFor={`${type}-${field.key}`}>{field.label}</label>
+              <input
+                id={`${type}-${field.key}`}
+                type={field.type || 'text'}
+                autoComplete="off"
+                placeholder={field.placeholder}
+                value={state.inputs[field.key] ?? ''}
+                required={field.required}
+                onChange={(event) => handleChange(field.key, event.target.value)}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="search-actions">
+          <NeonButton type="submit" disabled={disabled || state.status === 'loading'}>
+            {state.status === 'loading' ? 'Searching…' : 'Search'}
+          </NeonButton>
+        </div>
+        <div className="search-status">{state.message}</div>
+        {state.status === 'loading' ? (
+          <div className="loader" aria-label="Searching" />
+        ) : state.results.length ? (
+          <ul className="search-results">
+            {state.results.map((item, index) => (
+              <li key={`${type}-result-${item.id ?? index}`} className="search-result-card">
+                <div className="search-result-meta">
+                  <div className="search-primary">{config.renderPrimary(item)}</div>
+                  <div className="search-secondary">{config.renderSecondary(item)}</div>
+                </div>
+                <NeonButton
+                  type="button"
+                  onClick={() => onSelect(type, item)}
+                  disabled={disabled}
+                >
+                  Add
+                </NeonButton>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </form>
+    </GlassCard>
+  );
+};
+
+function App() {
+  const [lists, setLists] = useState(ensureLists(initialState.lists));
+  const [selectedList, setSelectedList] = useState(
+    LIST_ORDER.includes(initialState.selectedList) ? initialState.selectedList : 'artist',
+  );
+  const [banners, setBanners] = useState(withBannerIds(initialState.banners));
+  const [searchState, setSearchState] = useState(makeInitialSearchState);
+  const [pending, setPending] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const labels = useMemo(() => initialState.labels || {}, []);
+
+  const pushBanner = useCallback((message, isError = false) => {
+    if (!message) {
+      return;
+    }
+    setBanners((current) => {
+      const next = [...current, ...withBannerIds([{ message, isError }])];
+      return next.slice(-5);
+    });
+  }, []);
+
+  const replaceBanners = useCallback((items) => {
+    setBanners(withBannerIds(items));
+  }, []);
+
+  const refreshLists = useCallback(
+    async (targetKind = selectedList) => {
+      setRefreshing(true);
+      try {
+        const response = await fetch('/api/lists?kind=all', {
+          headers: { Accept: 'application/json' },
+        });
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data?.error || 'Failed to refresh lists.');
+        }
+        if (data?.lists) {
+          setLists(ensureLists(data.lists));
+        }
+        if (targetKind && LIST_ORDER.includes(targetKind)) {
+          setSelectedList(targetKind);
+        }
+      } catch (error) {
+        pushBanner(error.message || 'Unable to refresh lists.', true);
+      } finally {
+        setRefreshing(false);
+      }
+    },
+    [pushBanner, selectedList],
+  );
+
+  useEffect(() => {
+    if (initialState.banners?.length) {
+      replaceBanners(initialState.banners);
+    }
+  }, [replaceBanners]);
+
+  const handleDismissBanner = useCallback((id) => {
+    setBanners((current) => current.filter((banner) => banner.id !== id));
+  }, []);
+
+  const handleInputChange = useCallback((type, key, value) => {
+    setSearchState((current) => ({
+      ...current,
+      [type]: {
+        ...current[type],
+        inputs: {
+          ...current[type].inputs,
+          [key]: value,
+        },
+      },
+    }));
+  }, []);
+
+  const runSearch = useCallback(async (type) => {
+    const config = SEARCH_CONFIG[type];
+    if (!config) {
+      return;
+    }
+    const inputs = searchState[type].inputs;
+    const query = config.buildQuery(inputs);
+    if (!query) {
+      setSearchState((current) => ({
+        ...current,
+        [type]: {
+          ...current[type],
+          status: 'error',
+          message: 'Please provide search details.',
+        },
+      }));
+      return;
+    }
+    setSearchState((current) => ({
+      ...current,
+      [type]: {
+        ...current[type],
+        status: 'loading',
+        message: 'Searching…',
+        results: [],
+      },
+    }));
+
+    try {
+      const response = await fetch(`${config.endpoint}?q=${encodeURIComponent(query)}`, {
+        headers: { Accept: 'application/json' },
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data?.error || 'Search failed.');
+      }
+      const results = Array.isArray(data?.results) ? data.results : [];
+      setSearchState((current) => ({
+        ...current,
+        [type]: {
+          ...current[type],
+          status: 'ready',
+          message: results.length ? 'Select an item to add.' : 'No results found.',
+          results,
+        },
+      }));
+    } catch (error) {
+      setSearchState((current) => ({
+        ...current,
+        [type]: {
+          ...current[type],
+          status: 'error',
+          message: error.message || 'Search failed.',
+          results: [],
+        },
+      }));
+      pushBanner(error.message || 'Search failed.', true);
+    }
+  }, [pushBanner, searchState]);
+
+  const handleSelectResult = useCallback(
+    async (type, item) => {
+      const config = SEARCH_CONFIG[type];
+      if (!config) {
+        return;
+      }
+      const payload = config.buildPayload(item);
+      if (!payload) {
+        pushBanner('The selected item is missing an identifier.', true);
+        return;
+      }
+      setPending(true);
+      try {
+        const response = await fetch(config.selectEndpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+        const data = await response.json();
+        if (!response.ok || data?.success === false) {
+          throw new Error(data?.error || data?.message || 'Failed to add entry.');
+        }
+        await refreshLists(type);
+        if (data?.message) {
+          pushBanner(data.message, false);
+        } else {
+          pushBanner(config.successMessage || 'Entry added successfully.', false);
+        }
+        setSearchState((current) => ({
+          ...current,
+          [type]: {
+            inputs: config.clearOnSuccess ? { ...defaultSearchInputs[type] } : current[type].inputs,
+            results: [],
+            status: 'ready',
+            message: config.clearOnSuccess ? config.idleMessage : 'Entry queued successfully.',
+          },
+        }));
+      } catch (error) {
+        pushBanner(error.message || 'Failed to add entry.', true);
+        setSearchState((current) => ({
+          ...current,
+          [type]: {
+            ...current[type],
+            status: 'error',
+            message: error.message || 'Failed to add entry.',
+          },
+        }));
+      } finally {
+        setPending(false);
+      }
+    },
+    [pushBanner, refreshLists],
+  );
+
+  const handleRemoveEntry = useCallback(
+    async (kind, index) => {
+      setPending(true);
+      try {
+        const response = await fetch('/delete', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({
+            list: kind,
+            selected: selectedList,
+            index,
+          }),
+        });
+        const data = await response.json();
+        if (!response.ok || data?.success === false) {
+          throw new Error(data?.error || data?.message || 'Failed to remove entry.');
+        }
+        if (data?.lists) {
+          setLists(ensureLists(data.lists));
+        }
+        if (data?.selected && LIST_ORDER.includes(data.selected)) {
+          setSelectedList(data.selected);
+        }
+        if (data?.banners?.length) {
+          replaceBanners(data.banners);
+        } else if (data?.message) {
+          pushBanner(data.message, false);
+        }
+      } catch (error) {
+        pushBanner(error.message || 'Failed to remove entry.', true);
+      } finally {
+        setPending(false);
+      }
+    },
+    [pushBanner, replaceBanners, selectedList],
+  );
+
+  const handlePhotosAction = useCallback(
+    async (endpoint) => {
+      setPending(true);
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({ selected: selectedList }),
+        });
+        const data = await response.json();
+        if (!response.ok || data?.success === false) {
+          throw new Error(data?.error || data?.message || 'Action failed.');
+        }
+        if (data?.lists) {
+          setLists(ensureLists(data.lists));
+        }
+        if (data?.selected && LIST_ORDER.includes(data.selected)) {
+          setSelectedList(data.selected);
+        }
+        if (data?.banners?.length) {
+          replaceBanners(data.banners);
+        } else if (data?.message) {
+          pushBanner(data.message, false);
+        }
+      } catch (error) {
+        pushBanner(error.message || 'Action failed.', true);
+      } finally {
+        setPending(false);
+      }
+    },
+    [pushBanner, replaceBanners, selectedList],
+  );
+
+  const selectedConfig = SEARCH_CONFIG[selectedList];
+  const selectedSearchState = searchState[selectedList];
+  const listOptions = LIST_ORDER.map((kind) => ({
+    value: kind,
+    label: labels[kind] || kind.charAt(0).toUpperCase() + kind.slice(1),
+  }));
+
+  return (
+    <div className="layout">
+      <header className="header-intro">
+        <span className="eyebrow">Queue control</span>
+        <h1>OrpheusDL Lists</h1>
+        <p>
+          Manage the artists, albums, and tracks that OrpheusDL will synchronise. Search Qobuz, curate your queue, and keep artwork up to date—all from a modern React interface powered by ReactBits-inspired components.
+        </p>
+      </header>
+
+      <BannerStack banners={banners} onDismiss={handleDismissBanner} />
+
+      <GlassCard>
+        <div className="list-header">
+          <h2>Choose a list to manage</h2>
+          <Tabs value={selectedList} onChange={setSelectedList} options={listOptions} />
+        </div>
+        <div className="list-actions">
+          <NeonButton
+            type="button"
+            onClick={() => handlePhotosAction('/download-photos')}
+            disabled={pending}
+          >
+            Download missing artwork
+          </NeonButton>
+          <NeonButton
+            type="button"
+            variant="danger"
+            onClick={() => handlePhotosAction('/purge-photos')}
+            disabled={pending}
+          >
+            Purge cached artwork
+          </NeonButton>
+        </div>
+      </GlassCard>
+
+      {selectedConfig ? (
+        <SearchPanel
+          type={selectedList}
+          config={selectedConfig}
+          state={selectedSearchState}
+          onInputChange={handleInputChange}
+          onSubmit={runSearch}
+          onSelect={handleSelectResult}
+          disabled={pending}
+        />
+      ) : null}
+
+      <EntryList
+        kind={selectedList}
+        label={labels[selectedList] || selectedList}
+        entries={lists[selectedList]}
+        onRemove={handleRemoveEntry}
+        disabled={pending}
+        isRefreshing={refreshing}
+      />
+    </div>
+  );
+}
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/webui/styles.css
+++ b/webui/styles.css
@@ -1,0 +1,533 @@
+:root {
+  color-scheme: dark;
+  --surface: rgba(10, 17, 34, 0.78);
+  --surface-soft: rgba(15, 23, 42, 0.6);
+  --surface-strong: rgba(21, 30, 52, 0.85);
+  --border: rgba(148, 163, 184, 0.18);
+  --border-strong: rgba(99, 102, 241, 0.42);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --accent-start: #6366f1;
+  --accent-end: #06b6d4;
+  --success: #22d3ee;
+  --danger: #f87171;
+  --warning: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: #030712;
+  color: var(--text-primary);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+body.app-shell {
+  position: relative;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+body.app-shell::before,
+body.app-shell::after {
+  content: '';
+  position: fixed;
+  inset: -20vh -40vw auto;
+  height: 60vh;
+  width: 80vw;
+  pointer-events: none;
+  background: radial-gradient(circle at center, rgba(79, 70, 229, 0.38), transparent 60%);
+  filter: blur(12px);
+  transform: translate3d(0, 0, 0);
+  animation: aurora-shift 18s infinite linear;
+  opacity: 0.9;
+}
+
+body.app-shell::after {
+  inset: auto -35vw -30vh auto;
+  height: 70vh;
+  width: 70vw;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.35), transparent 65%);
+  animation-delay: -7s;
+}
+
+@keyframes aurora-shift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(10%, -6%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(-8%, 4%, 0) scale(1);
+  }
+}
+
+.noscript {
+  margin: 1rem auto;
+  max-width: 960px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  padding: 1rem 1.25rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.layout {
+  position: relative;
+  isolation: isolate;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 5vw, 3.5rem) clamp(1.25rem, 5vw, 3rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2rem);
+}
+
+.header-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.header-intro .eyebrow {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.header-intro h1 {
+  margin: 0;
+  font-size: clamp(2.1rem, 3vw, 2.8rem);
+  font-weight: 700;
+}
+
+.header-intro p {
+  margin: 0;
+  max-width: 640px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.banner-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.banner {
+  position: relative;
+  padding: 0.95rem 1.1rem;
+  border-radius: 0.85rem;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.28), rgba(6, 182, 212, 0.24));
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  box-shadow: 0 22px 35px rgba(12, 18, 34, 0.45);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.banner.is-error {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.32), rgba(248, 150, 108, 0.28));
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.banner button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+}
+
+.banner button:hover {
+  opacity: 1;
+}
+
+.reactbits-card {
+  position: relative;
+  border-radius: 1.1rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: 0 24px 48px rgba(4, 7, 16, 0.55);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.reactbits-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.24), rgba(6, 182, 212, 0.18));
+  opacity: 0.65;
+  filter: blur(24px);
+  transform: translateZ(-1px);
+  z-index: -1;
+}
+
+.reactbits-card--padded {
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.reactbits-card--flush {
+  padding: clamp(1rem, 2.5vw, 1.6rem);
+}
+
+.list-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.list-header h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.3vw, 1.75rem);
+}
+
+.count-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.reactbits-tabs {
+  display: inline-flex;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: var(--surface-soft);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  gap: 0.25rem;
+}
+
+.reactbits-tab {
+  position: relative;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.reactbits-tab::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.55), rgba(6, 182, 212, 0.55));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  z-index: -1;
+}
+
+.reactbits-tab:hover {
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+.reactbits-tab.is-active {
+  color: #0f172a;
+}
+
+.reactbits-tab.is-active::after {
+  opacity: 1;
+}
+
+.list-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.reactbits-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  color: #0f172a;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(79, 70, 229, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.reactbits-button::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.75), rgba(6, 182, 212, 0.65));
+  filter: blur(10px);
+  opacity: 0.7;
+  z-index: -1;
+  transition: opacity 0.2s ease;
+}
+
+.reactbits-button:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 18px 32px rgba(56, 189, 248, 0.35);
+}
+
+.reactbits-button:hover::before {
+  opacity: 1;
+}
+
+.reactbits-button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+  transform: none;
+  box-shadow: none;
+}
+
+.reactbits-button.is-danger {
+  background: linear-gradient(135deg, #f87171, #fbbf24);
+  color: #0f172a;
+  box-shadow: 0 12px 28px rgba(248, 113, 113, 0.32);
+}
+
+.reactbits-button.is-ghost {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-secondary);
+  box-shadow: none;
+}
+
+.reactbits-button.is-ghost::before {
+  display: none;
+}
+
+.field-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.field-group label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.field-group input {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--text-primary);
+  border-radius: 0.8rem;
+  font-size: 1rem;
+  padding: 0.65rem 0.9rem;
+  transition: border 0.18s ease, box-shadow 0.18s ease;
+}
+
+.field-group input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.75);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.search-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.search-status {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.search-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.search-results {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.search-result-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.15rem;
+  border-radius: 1rem;
+  background: var(--surface-strong);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.search-result-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.search-primary {
+  font-weight: 600;
+}
+
+.search-secondary {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.entry-collection {
+  display: grid;
+  gap: 1rem;
+}
+
+.entry-card {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.2rem;
+  border-radius: 1.05rem;
+  background: var(--surface-strong);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.entry-card.no-media {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.entry-thumb {
+  width: 96px;
+  height: 96px;
+  border-radius: 0.9rem;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.3), rgba(6, 182, 212, 0.25));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.entry-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.entry-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.entry-title {
+  font-weight: 600;
+  font-size: 1.05rem;
+  word-break: break-word;
+}
+
+.entry-subtitle,
+.entry-meta {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.empty-state {
+  padding: 1rem;
+  border-radius: 0.8rem;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.loader {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 3px solid rgba(148, 163, 184, 0.25);
+  border-top-color: var(--accent-start);
+  animation: spin 0.9s linear infinite;
+  margin: 0 auto;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 960px) {
+  .entry-card {
+    grid-template-columns: minmax(0, 1fr);
+    text-align: left;
+  }
+
+  .entry-card .reactbits-button {
+    justify-content: center;
+  }
+
+  .entry-thumb {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1 / 1;
+  }
+}
+
+@media (max-width: 720px) {
+  .list-actions {
+    justify-content: flex-start;
+  }
+
+  .search-result-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .reactbits-tabs {
+    width: 100%;
+  }
+
+  .reactbits-tab {
+    flex: 1;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- serve a modern React single-page application for managing OrpheusDL lists with ReactBits-inspired components
- extend list_ui_server to expose JSON endpoints, static assets, and JSON responses for list mutations
- add a dedicated webui bundle with React logic and styling for search, queue management, and artwork actions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d614363564832f807bd296815ade8a