### PR TITLE
Remove setup-python from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Install lint dependencies
         run: python -m pip install --upgrade pip ruff
 
@@ -38,11 +33,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- remove redundant actions/setup-python steps from lint and test jobs
- rely on the preinstalled Python interpreter on the self-hosted runner

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d61920b6d8832f8d735126a2678089