### PR TITLE
Use python3 in self-hosted CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install lint dependencies
-        run: python -m pip install --upgrade pip ruff
+        run: python3 -m pip install --upgrade pip ruff
 
       - name: Run ruff
         run: ruff check .
 
       - name: Verify Python bytecode compiles
-        run: python -m compileall list_ui_server.py notifications.py tests
+        run: python3 -m compileall list_ui_server.py notifications.py tests
 
   tests:
     name: Tests
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install pytest requests
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pytest requests
 
       - name: Run pytest
         run: pytest


### PR DESCRIPTION
## Summary
- switch self-hosted workflow steps to invoke python3 instead of python

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61cf38b1c832f95627d1f9b9714f4