### PR TITLE
Create virtualenv for self-hosted CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,17 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Install lint dependencies
-        run: python -m pip install --upgrade pip ruff
+      - name: Set up Python environment
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip ruff
 
       - name: Run ruff
-        run: ruff check .
+        run: .venv/bin/ruff check .
 
       - name: Verify Python bytecode compiles
-        run: python -m compileall list_ui_server.py notifications.py tests
+        run: .venv/bin/python -m compileall list_ui_server.py notifications.py tests
 
   tests:
     name: Tests
@@ -36,11 +39,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install pytest requests
 
       - name: Run pytest
-        run: pytest
+        run: .venv/bin/pytest
 
   docker:
     name: Docker build


### PR DESCRIPTION
## Summary
- create and use a virtual environment in the self-hosted lint and test jobs
- install linting and test dependencies inside the venv to avoid system package restrictions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61cf38b1c832f95627d1f9b9714f4