### PR TITLE
Enable multi-architecture Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Set up QEMU emulation
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -28,6 +34,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ghcr.io/theminecraftguyguru/orpheusdl-container:latest
             ghcr.io/theminecraftguyguru/orpheusdl-container:${{ github.sha }}


### PR DESCRIPTION
## Summary
- enable QEMU emulation and Docker Buildx in the publishing workflow
- publish Linux amd64, arm64, and arm/v7 container variants to GHCR

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d62afd4f7c832fa0c630b9bd50216e