### PR TITLE
Exclude external directory from CI lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip ruff
 
       - name: Run ruff
-        run: .venv/bin/ruff check .
+        run: .venv/bin/ruff check . --exclude external
 
       - name: Verify Python bytecode compiles
         run: .venv/bin/python -m compileall list_ui_server.py notifications.py tests


### PR DESCRIPTION
## Summary
- update the CI lint job to skip the vendored `external` directory when running Ruff

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d62ba64520832f9d2ae9242a28d21f