### PR TITLE
Add Alpine image libraries required for Pillow build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,18 @@ RUN apk add --no-cache \
         ffmpeg \
         gcc \
         git \
+        jpeg-dev \
+        lcms2-dev \
         libffi-dev \
+        libwebp-dev \
         musl-dev \
+        openjpeg-dev \
         openssl-dev \
         python3 \
         python3-dev \
-        py3-pip
+        py3-pip \
+        tiff-dev \
+        zlib-dev
 
 # Set working dir
 WORKDIR /app


### PR DESCRIPTION
## Summary
- add the zlib and supporting image library development packages to the Alpine base image to satisfy Pillow's build requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63282cb44832fbe012ec1f1735ba6