### PR TITLE
Add workflow support for settings.json-format image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "settings.json-format" ]
   workflow_dispatch:
 
 jobs:
@@ -29,12 +29,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute image tags
+        id: metadata
+        run: |
+          tags="ghcr.io/theminecraftguyguru/orpheusdl-container:${GITHUB_SHA}"
+          ref_name="${GITHUB_REF##*/}"
+
+          if [ "${ref_name}" = "main" ]; then
+            tags=$'ghcr.io/theminecraftguyguru/orpheusdl-container:latest\n'"${tags}"
+          elif [ "${ref_name}" = "settings.json-format" ]; then
+            tags=$'ghcr.io/theminecraftguyguru/orpheusdl-container:settings-json-format\n'"${tags}"
+          fi
+
+          {
+            echo 'tags<<EOF'
+            echo "${tags}"
+            echo 'EOF'
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: |
-            ghcr.io/theminecraftguyguru/orpheusdl-container:latest
-            ghcr.io/theminecraftguyguru/orpheusdl-container:${{ github.sha }}
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ docker compose run --rm --entrypoint /bin/bash orpheusdl
 ```yaml
 services:
   orpheusdl:
-    image: ghcr.io/theminecraftguyguru/orpheusdl-container:latest
+    image: ghcr.io/theminecraftguyguru/orpheusdl-container:settings-json-format
     container_name: orpheusdl
     ports:
       - "8080:8080"
@@ -85,6 +85,9 @@ services:
 
 > **Note:** The compose example above mounts host folders for data, configuration, and modules.
 > Adjust the paths and ports to fit your environment before running `docker compose up -d`.
+>
+> Use the `settings-json-format` image tag shown here when you want the container build from this branch.
+> The `latest` tag continues to track the `main` branch builds.
 
 ## Environment variables
 
@@ -132,5 +135,5 @@ Mount the following directories to keep your library and queue between container
    docker build -t orpheusdl .
    ```
 
-Once built, the locally tagged image behaves the same as the published `ghcr.io/theminecraftguyguru/orpheusdl-container:latest` image.
+Once built, the locally tagged image behaves the same as the published `ghcr.io/theminecraftguyguru/orpheusdl-container:settings-json-format` image for this branch.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   orpheusdl:
-    image: ghcr.io/theminecraftguyguru/orpheusdl-container:latest
+    image: ghcr.io/theminecraftguyguru/orpheusdl-container:settings-json-format
     container_name: orpheusdl
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- build and push container images when the `settings.json-format` branch updates
- emit a dedicated `settings-json-format` image tag alongside existing branch tags
- update the compose example and docs to reference the branch-specific tag

## Testing
- not run (workflow and documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d64fd5f334832f88b4048640cc4a6b