### PR TITLE
Fix module directory initialization check

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -463,7 +463,7 @@ PY
 
 if [ -d /app/modules-default ]; then
     mkdir -p /orpheusdl/modules
-    if ! find /orpheusdl/modules -mindepth 1 -maxdepth 1 -print -quit >/dev/null 2>&1; then
+    if [ -z "$(find /orpheusdl/modules -mindepth 1 -maxdepth 1 -print -quit)" ]; then
         cp -a /app/modules-default/. /orpheusdl/modules/
     fi
 fi


### PR DESCRIPTION
## Summary
- ensure the modules default copy runs only when the target directory is empty by checking the find output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d656f2f9ac832fbe67b78c26aa9fff